### PR TITLE
refactor: made useTabs as hook

### DIFF
--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -1,8 +1,8 @@
 import classNames from "classnames";
-import React, { FC, useEffect, useLayoutEffect, useRef, useState } from "react";
+import React, { FC,useRef } from "react";
 import { Category } from "unicode-emoji";
+import { useTabs } from "../utils/useTabs";
 
-import { LOCAL_STORAGE_RECENT } from "../constants";
 import { ActivityIcon } from "../icons/ActivityIcon";
 import { FlagsIcon } from "../icons/FlagsIcon";
 import { FoodIcon } from "../icons/FoodIcon";
@@ -90,64 +90,8 @@ export const Tabs: FC<Props> = ({
   styles,
 }) => {
   const tabsRef = useRef<(HTMLButtonElement | null)[]>([]);
-  const [showRecent, setShowRecent] = useState(false);
-
-  const [indicatorState, setIndicatorState] = useState({
-    width: 0,
-    left: 0,
-    shouldAnimate: true,
-  });
-
-  const updateIndicatorState = () => {
-    const tab = tabsRef.current[value];
-    if (tab) {
-      setIndicatorState({
-        ...indicatorState,
-        width: tab.offsetWidth,
-        left: tab.offsetLeft,
-        shouldAnimate: false,
-      });
-    }
-  };
-
-  useEffect(() => {
-    if (localStorage.getItem(LOCAL_STORAGE_RECENT)) {
-      setShowRecent(true);
-    }
-    // Position 0 is for recent and might not be displayed
-    const tab = tabsRef.current[1];
-    if (tab) {
-      setIndicatorState({
-        ...indicatorState,
-        shouldAnimate: false,
-        width: tab.offsetWidth,
-      });
-    }
-  }, [tabsRef]);
-
-  useLayoutEffect(() => {
-    const handleResize = () => {
-      updateIndicatorState();
-    };
-
-    window.addEventListener("resize", handleResize);
-
-    return () => {
-      window.removeEventListener("resize", handleResize);
-    };
-  }, [updateIndicatorState]);
-
-  useEffect(() => {
-    const tab = tabsRef.current[value];
-    if (tab) {
-      setIndicatorState({
-        ...indicatorState,
-        shouldAnimate: true,
-        width: tab.offsetWidth,
-        left: tab.offsetLeft,
-      });
-    }
-  }, [value]);
+  const {indicatorState, showRecent} = useTabs(tabsRef, value)
+  
 
   const classes = classNames(
     "flex items-center text-gray-400 dark:text-primary-300 dark:shadow-sm h-full overflow-hidden",

--- a/src/utils/useTabs.ts
+++ b/src/utils/useTabs.ts
@@ -1,0 +1,67 @@
+import { LOCAL_STORAGE_RECENT } from '../constants';
+import {useEffect, useLayoutEffect, useState} from 'react';
+export const useTabs = (tabsRef: React.MutableRefObject<(HTMLButtonElement | null)[]>, value: number) => {
+    
+    const [showRecent, setShowRecent] = useState(false);
+    const [indicatorState, setIndicatorState] = useState({
+        width: 0,
+        left: 0,
+        shouldAnimate: true,
+      });
+
+      const updateIndicatorState = () => {
+        const tab = tabsRef.current[value];
+        if (tab) {
+          setIndicatorState({
+            ...indicatorState,
+            width: tab.offsetWidth,
+            left: tab.offsetLeft,
+            shouldAnimate: false,
+          });
+        }
+      };
+
+      useEffect(() => {
+        if (localStorage.getItem(LOCAL_STORAGE_RECENT)) {
+          setShowRecent(true);
+        }
+        // Position 0 is for recent and might not be displayed
+        const tab = tabsRef.current[1];
+        if (tab) {
+          setIndicatorState({
+            ...indicatorState,
+            shouldAnimate: false,
+            width: tab.offsetWidth,
+          });
+        }
+      }, [tabsRef]);
+
+      useLayoutEffect(() => {
+        const handleResize = () => {
+          updateIndicatorState();
+        };
+    
+        window.addEventListener("resize", handleResize);
+    
+        return () => {
+          window.removeEventListener("resize", handleResize);
+        };
+      }, [updateIndicatorState]);
+
+      useEffect(() => {
+        const tab = tabsRef.current[value];
+        if (tab) {
+          setIndicatorState({
+            ...indicatorState,
+            shouldAnimate: true,
+            width: tab.offsetWidth,
+            left: tab.offsetLeft,
+          });
+        }
+      }, [value]);
+
+      return {
+          showRecent,
+          indicatorState
+      }
+};


### PR DESCRIPTION
Changes:

Refactor tabs state logic to be used as a hook. Making it easier to share.