### PR TITLE
Fix autocomplete

### DIFF
--- a/src/components/Emoji/components/EmojiImg/EmojiImg.tsx
+++ b/src/components/Emoji/components/EmojiImg/EmojiImg.tsx
@@ -8,6 +8,7 @@ interface EmojiImgProps {
   set?: EmojiSet;
   quality?: EmojiQuality;
   sheetSize?: number;
+  keywords?: string[];
 }
 
 export const EmojiImg: FC<EmojiImgProps> = ({
@@ -16,6 +17,7 @@ export const EmojiImg: FC<EmojiImgProps> = ({
   quality = "clean",
   sheetSize = 64,
   set = "apple",
+  keywords,
 }) => {
   const img = `https://cdn.jsdelivr.net/npm/emoji-datasource-${set}-split@1.0.6/img/sheets-${quality}/${sheetSize}/${set}/${emoji.img}`;
 
@@ -23,6 +25,7 @@ export const EmojiImg: FC<EmojiImgProps> = ({
     <span
       data-testid="emoji-img"
       data-image={img}
+      title={keywords?.join(",")}
       aria-label={emoji.native}
       className="emoji-img"
       style={{

--- a/src/components/Emoji/components/EmojiNative/EmojiNative.tsx
+++ b/src/components/Emoji/components/EmojiNative/EmojiNative.tsx
@@ -3,13 +3,19 @@ import React, { FC } from "react";
 interface EmojiNative {
   emoji: string;
   size?: number;
+  keywords?: string[];
 }
 
-export const EmojiNative: FC<EmojiNative> = ({ emoji, size = 32 }) => {
+export const EmojiNative: FC<EmojiNative> = ({
+  emoji,
+  size = 32,
+  keywords,
+}) => {
   return (
     <span
       data-testid="emoji-native"
       aria-label={emoji}
+      title={keywords?.join(",")}
       className="emoji-native"
       style={{ fontSize: `${size}px` }}
     >

--- a/src/components/EmojiPicker/components/Emoji/Emoji.tsx
+++ b/src/components/EmojiPicker/components/Emoji/Emoji.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from "react";
-import { BaseEmoji, EmojiQuality, EmojiSet } from "types/emoji";
+import { Emoji as BaseEmoji, EmojiQuality, EmojiSet } from "types/emoji";
 
 import { EmojiImg } from "../../../Emoji/components/EmojiImg";
 import { EmojiNative } from "../../../Emoji/components/EmojiNative";
@@ -15,8 +15,14 @@ interface EmojiProps {
 
 export const Emoji: FC<EmojiProps> = ({ data: emoji, ...config }) => {
   if (config.set === "native") {
-    return <EmojiNative size={config.size} emoji={emoji.native} />;
+    return (
+      <EmojiNative
+        size={config.size}
+        keywords={emoji.keywords}
+        emoji={emoji.native}
+      />
+    );
   }
 
-  return <EmojiImg emoji={emoji} {...config} />;
+  return <EmojiImg emoji={emoji} keywords={emoji.keywords} {...config} />;
 };

--- a/src/utils/getEmojis.ts
+++ b/src/utils/getEmojis.ts
@@ -11,7 +11,7 @@ export const searchEmoji = (text: string, set: EmojiSet, version: Version) => {
     (emoji) =>
       (set === "native" || emoji[set] === 1) &&
       emoji.version <= version &&
-      emoji.keywords.some((word: string) => word.startsWith(text))
+      emoji.keywords.some((word: string) => word.includes(text))
   );
 };
 


### PR DESCRIPTION
- Add title with keywords to the emojis
- Search emojis using `.includes` rather than `.startsWith`